### PR TITLE
Use Accent Color or Tint Color for ORKTaskViewController

### DIFF
--- a/Example/ExampleApp/Questionnaire/ORKOrderedTaskView.swift
+++ b/Example/ExampleApp/Questionnaire/ORKOrderedTaskView.swift
@@ -13,6 +13,7 @@ import UIKit
 
 struct ORKOrderedTaskView: UIViewControllerRepresentable {
     private let tasks: ORKOrderedTask
+    private let tintColor: Color
     // We need to have a non-weak reference here to keep the retain count of the delegate above 0.
     private var delegate: ORKTaskViewControllerDelegate
     
@@ -20,17 +21,25 @@ struct ORKOrderedTaskView: UIViewControllerRepresentable {
     /// - Parameters:
     ///   - tasks: The `ORKOrderedTask` that should be displayed by the `ORKTaskViewController`
     ///   - delegate: An `ORKTaskViewControllerDelegate` that handles delegate calls from the `ORKTaskViewController`. If no  view controller delegate is provided the view uses an instance of `CKUploadFHIRTaskViewControllerDelegate`.
-    init(tasks: ORKOrderedTask, delegate: ORKTaskViewControllerDelegate) {
+    init(
+        tasks: ORKOrderedTask,
+        delegate: ORKTaskViewControllerDelegate,
+        tintColor: Color = Color(UIColor(named: "AccentColor") ?? .tintColor)
+    ) {
         self.tasks = tasks
+        self.tintColor = tintColor
         self.delegate = delegate
     }
     
     
-    func updateUIViewController(_ uiViewController: ORKTaskViewController, context: Context) {}
+    func updateUIViewController(_ uiViewController: ORKTaskViewController, context: Context) {
+        uiViewController.view.tintColor = UIColor(tintColor)
+    }
     
     func makeUIViewController(context: Context) -> ORKTaskViewController {
         // Create a new instance of the view controller and pass in the assigned delegate.
         let viewController = ORKTaskViewController(task: tasks, taskRun: nil)
+        viewController.view.tintColor = UIColor(tintColor)
         viewController.delegate = delegate
         return viewController
     }

--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
         .library(name: "FHIRQuestionnaires", targets: ["FHIRQuestionnaires"])
     ],
     dependencies: [
-        .package(url: "https://github.com/StanfordBDHG/ResearchKit.git", from: "2.1.1-main"),
+        .package(url: "https://github.com/StanfordBDHG/ResearchKit.git", exact: "2.1.1-main"),
         .package(url: "https://github.com/apple/FHIRModels.git", .upToNextMajor(from: "0.4.0"))
     ],
     targets: [


### PR DESCRIPTION
# Use Accent Color or Tint Color for ORKTaskViewController

## :recycle: Current situation & Problem
The accent color and or tint color of the SwiftUI-based application is currently not propagated to the UIKit-based ResearchKit views. 

## :bulb: Proposed solution
This PR incorporates the feedback provided in https://github.com/ResearchKit/ResearchKit/issues/1521 to the ResearchKitOnFHIR project. Thank you @cbaker6 for the help!

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).

