### PR TITLE
EnableBehavior defaults to ALL if not specified

### DIFF
--- a/Sources/FHIRQuestionnaires/Resources/MultipleEnableWhen.json
+++ b/Sources/FHIRQuestionnaires/Resources/MultipleEnableWhen.json
@@ -147,7 +147,6 @@
           "answerInteger": 12
         }
       ],
-      "enableBehavior": "all"
     }
   ]
 }

--- a/Sources/ResearchKitOnFHIR/FHIRToResearchKit/NavigationRules.swift
+++ b/Sources/ResearchKitOnFHIR/FHIRToResearchKit/NavigationRules.swift
@@ -22,10 +22,11 @@ extension ORKNavigableOrderedTask {
                 continue
             }
 
-            if enableWhen.count > 1, let enableWhenBehavior = question.enableBehavior?.value {
+            if enableWhen.count > 1 {
+                let enableBehavior = question.enableBehavior?.value ?? .all
                 let allPredicates = enableWhen.compactMap { try? $0.predicate }
                 var compoundPredicate = NSCompoundPredicate()
-                switch enableWhenBehavior {
+                switch enableBehavior {
                 case .all:
                     compoundPredicate = NSCompoundPredicate(orPredicateWithSubpredicates: allPredicates)
                 case .any:


### PR DESCRIPTION
<!--

This source file is part of the Stanford Biodesign for Digital Health open-source project

SPDX-FileCopyrightText: 2022 Stanford Biodesign for Digital Health and the project authors (see CONTRIBUTORS.md)

SPDX-License-Identifier: MIT

-->

# EnableBehavior defaults to ALL if not specified

## :recycle: Current situation & Problem
If a QuestionnaireItem has > 1 `enableWhen` expressions, but does not have `enableBehavior` specified, the `enableWhen` expressions are currently not applied. Since `enableBehavior` is [not a mandatory element](https://build.fhir.org/ig/HL7/sdc/StructureDefinition-sdc-questionnaire-definitions.html#Questionnaire.item.enableBehavior) in the HL7 SDC it may not be present and a default behavior should exist.

## :bulb: Proposed solution
This PR defaults `enableBehavior` to ALL, i.e. the question is shown only when all the `enableWhen` expressions are satisfied. We also update a UI test to cover this situation.

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [X] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).

