### PR TITLE
Fix for keyboard safe area covering input fields

### DIFF
--- a/Example/ExampleApp/Questionnaire/QuestionnaireView.swift
+++ b/Example/ExampleApp/Questionnaire/QuestionnaireView.swift
@@ -23,6 +23,7 @@ struct QuestionnaireView: View {
            let task = createTask(questionnaire: activeQuestionnaire) {
             ORKOrderedTaskView(tasks: task, delegate: ORKTaskFHIRDelegate(responseStorage))
                 .ignoresSafeArea(.container, edges: .bottom)
+                .ignoresSafeArea(.keyboard, edges: .bottom)
         } else {
             Text("ERROR_MESSAGE")
         }

--- a/Example/ExampleUITests/ExampleUITests.swift
+++ b/Example/ExampleUITests/ExampleUITests.swift
@@ -146,19 +146,19 @@ final class ExampleUITests: XCTestCase {
         // Fill in integer field
         let integerField = app.textFields.element
         integerField.tap()
-        integerField.typeText("1")
+        integerField.typeText("1\n")
         app.buttons["Next"].tap()
 
         // Fill in decimal field
         let decimalField = app.textFields.element
         decimalField.tap()
-        decimalField.typeText("1.5")
+        decimalField.typeText("1.5\n")
         app.buttons["Next"].tap()
 
         // Fill in quantity field
         let quantityField = app.textFields.element
         quantityField.tap()
-        quantityField.typeText("2.5")
+        quantityField.typeText("2.5\n")
 
         // Finish questionnaire
         app.buttons["Next"].tap()
@@ -427,7 +427,7 @@ final class ExampleUITests: XCTestCase {
 
         let integerField = app.textFields.element(boundBy: 0)
         integerField.tap()
-        integerField.typeText("12")
+        integerField.typeText("12\n")
         app.buttons["Next"].tap()
 
         // First result screen appears if at least one answer is correct.
@@ -450,7 +450,7 @@ final class ExampleUITests: XCTestCase {
         app.buttons["Next"].tap()
 
         integerField.tap()
-        integerField.typeText("2")
+        integerField.typeText("2\n")
         app.buttons["Next"].tap()
 
         // Only one result screen should appear.


### PR DESCRIPTION
<!--

This source file is part of the Stanford Biodesign for Digital Health open-source project

SPDX-FileCopyrightText: 2022 Stanford Biodesign for Digital Health and the project authors (see CONTRIBUTORS.md)

SPDX-License-Identifier: MIT

-->

# Fix for keyboard safe area covering input fields

## :recycle: Current situation & Problem
The keyboard safe area sometimes covers the input field and leaves a large room between the keyboard and the control buttons (skip and next). Refer to this [related issue](https://github.com/ResearchKit/ResearchKit/issues/1520).

## :bulb: Proposed solution
Resolves this issue by adding ` .ignoresSafeArea(.keyboard, edges: .bottom)` to the `ORKOrderedTaskView` which keeps the `Next` toolbar pinned to the bottom of the screen. Thank you @louie-apple for your help with this issue!

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [X] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).

