### PR TITLE
Add support for multiple selection questions

### DIFF
--- a/Example/ExampleUITests/ExampleUITests.swift
+++ b/Example/ExampleUITests/ExampleUITests.swift
@@ -114,15 +114,23 @@ final class ExampleUITests: XCTestCase {
         let app = XCUIApplication()
         app.launch()
 
-        let containedValueSetExampleButton = app.collectionViews.buttons["Contained ValueSet Example"]
-
         // Complete questionnaire
+        let containedValueSetExampleButton = app.collectionViews.buttons["Contained ValueSet Example"]
+        XCTAssert(containedValueSetExampleButton.waitForExistence(timeout: 2))
         containedValueSetExampleButton.tap()
-        app.tables.staticTexts["Yes"].tap()
-        app.buttons["Next"].tap()
+        
+        let yesButton = app.tables.staticTexts["Yes"]
+        XCTAssert(yesButton.waitForExistence(timeout: 2))
+        yesButton.tap()
+        
+        let nextButton = app.buttons["Next"]
+        XCTAssert(nextButton.waitForExistence(timeout: 2))
+        nextButton.tap()
 
         // Close the completion step
-        app.buttons["Done"].tap()
+        let doneButton = app.buttons["Done"]
+        XCTAssert(doneButton.waitForExistence(timeout: 2))
+        doneButton.tap()
 
         // Open context menu and view results
         containedValueSetExampleButton.press(forDuration: 1.0)
@@ -223,8 +231,7 @@ final class ExampleUITests: XCTestCase {
         app.launch()
 
         let dateTimeExampleButton = app.collectionViews.buttons["Date and Time Example"]
-
-        // Open questionnaire
+        XCTAssert(dateTimeExampleButton.waitForExistence(timeout: 2))
         dateTimeExampleButton.tap()
         
         let dateFormatter = DateFormatter()
@@ -241,6 +248,7 @@ final class ExampleUITests: XCTestCase {
         app.buttons["Next"].tap()
 
         // Chose a date and time
+        sleep(1)
         app.pickerWheels.element(boundBy: 0).adjust(toPickerWheelValue: dateFormatOfRandomDateInProximity("MMM d"))
         app.pickerWheels.element(boundBy: 1).adjust(toPickerWheelValue: dateFormatOfRandomDateInProximity("h"))
         app.pickerWheels.element(boundBy: 2).adjust(toPickerWheelValue: dateFormatOfRandomDateInProximity("mm"))
@@ -248,19 +256,27 @@ final class ExampleUITests: XCTestCase {
         app.buttons["Next"].tap()
 
         // Choose a time
+        sleep(1)
         app.pickerWheels.element(boundBy: 0).adjust(toPickerWheelValue: dateFormatOfRandomDateInProximity("h"))
         app.pickerWheels.element(boundBy: 1).adjust(toPickerWheelValue: dateFormatOfRandomDateInProximity("mm"))
         app.pickerWheels.element(boundBy: 2).adjust(toPickerWheelValue: dateFormatOfRandomDateInProximity("a"))
         app.buttons["Next"].tap()
 
         // Close the completion step
-        app.buttons["Done"].tap()
+        let doneButton = app.buttons["Done"]
+        XCTAssert(doneButton.waitForExistence(timeout: 2))
+        doneButton.tap()
 
         // Open context menu and view results
+        XCTAssert(dateTimeExampleButton.waitForExistence(timeout: 2))
         dateTimeExampleButton.press(forDuration: 1.0)
-        app.collectionViews.buttons["View Responses"].tap()
+        
+        let viewReponsesButton = app.collectionViews.buttons["View Responses"]
+        XCTAssert(viewReponsesButton.waitForExistence(timeout: 2))
+        viewReponsesButton.tap()
 
         // Check results
+        sleep(1)
         let buttonsInResultView = app.collectionViews.allElementsBoundByIndex[1].buttons
         XCTAssertEqual(buttonsInResultView.count, 1)
         buttonsInResultView.allElementsBoundByIndex[0].tap()
@@ -333,7 +349,7 @@ final class ExampleUITests: XCTestCase {
             XCTFail("Slider value is not a readable number.")
         }
     }
-
+    
     // MARK: UI Tests for Clinical Questionnaires
 
     func testPHQ9Example() throws {
@@ -451,47 +467,67 @@ final class ExampleUITests: XCTestCase {
         app.launch()
         
         let multipleEnableWhenButton = app.collectionViews.buttons["Multiple EnableWhen Expressions"]
+        XCTAssert(multipleEnableWhenButton.waitForExistence(timeout: 2))
         multipleEnableWhenButton.tap()
 
         // We will first answer all questions correctly
+        XCTAssert(app.tables.staticTexts["Yes"].waitForExistence(timeout: 2))
         app.tables.staticTexts["Yes"].tap()
+        XCTAssert(app.buttons["Next"].waitForExistence(timeout: 2))
         app.buttons["Next"].tap()
 
+        XCTAssert(app.tables.staticTexts["green"].waitForExistence(timeout: 2))
         app.tables.staticTexts["green"].tap()
+        XCTAssert(app.buttons["Next"].waitForExistence(timeout: 2))
         app.buttons["Next"].tap()
 
+        
         let integerField = app.textFields.element(boundBy: 0)
+        XCTAssert(integerField.waitForExistence(timeout: 2))
         integerField.tap()
         integerField.typeText("12\n")
+        XCTAssert(app.buttons["Next"].waitForExistence(timeout: 2))
         app.buttons["Next"].tap()
 
         // First result screen appears if at least one answer is correct.
+        XCTAssert(app.buttons["Next"].waitForExistence(timeout: 2))
         app.buttons["Next"].tap()
 
         // Second result screen appears if all answers are correct.
+        XCTAssert(app.buttons["Next"].waitForExistence(timeout: 2))
         app.buttons["Next"].tap()
 
         // Now the completion screen will appear with a "Done" button that we can tap
+        XCTAssert(app.buttons["Done"].waitForExistence(timeout: 2))
         app.buttons["Done"].tap()
 
         // Now we relaunch the survey
+        XCTAssert(multipleEnableWhenButton.waitForExistence(timeout: 2))
         multipleEnableWhenButton.tap()
 
         // This time we answer only one question correctly
+        XCTAssert(app.tables.staticTexts["Yes"].waitForExistence(timeout: 2))
         app.tables.staticTexts["Yes"].tap()
+        XCTAssert(app.buttons["Next"].waitForExistence(timeout: 2))
         app.buttons["Next"].tap()
 
+        XCTAssert(app.tables.staticTexts["orange"].waitForExistence(timeout: 2))
         app.tables.staticTexts["orange"].tap()
+        XCTAssert(app.buttons["Next"].waitForExistence(timeout: 2))
         app.buttons["Next"].tap()
 
+        XCTAssert(integerField.waitForExistence(timeout: 2))
         integerField.tap()
         integerField.typeText("2\n")
+        XCTAssert(app.buttons["Next"].waitForExistence(timeout: 2))
         app.buttons["Next"].tap()
 
         // Only one result screen should appear.
+        XCTAssert(app.buttons["Next"].waitForExistence(timeout: 2))
         app.buttons["Next"].tap()
 
         // Now the completion screen should appear.
+        XCTAssert(app.buttons["Done"].waitForExistence(timeout: 2))
         app.buttons["Done"].tap()
     }
 
@@ -500,14 +536,19 @@ final class ExampleUITests: XCTestCase {
         app.launch()
 
         let imageCaptureButton = app.collectionViews.buttons["Image Capture Example"]
+        XCTAssert(imageCaptureButton.waitForExistence(timeout: 2))
         imageCaptureButton.tap()
 
         // This example requires access to a device camera, which can't be simulated,
         // so we will get an error message.
-        XCTAssert(app.staticTexts["No camera found.  This step cannot be completed."].exists)
+        XCTAssert(app.staticTexts["No camera found.  This step cannot be completed."].waitForExistence(timeout: 2))
 
-        app.buttons["Skip"].tap()
+        let skipButton = app.buttons["Skip"]
+        XCTAssert(skipButton.waitForExistence(timeout: 2))
+        skipButton.tap()
 
-        app.buttons["Done"].tap()
+        let doneButton = app.buttons["Done"]
+        XCTAssert(doneButton.waitForExistence(timeout: 2))
+        doneButton.tap()
     }
 }

--- a/Example/ExampleUITests/ExampleUITests.swift
+++ b/Example/ExampleUITests/ExampleUITests.swift
@@ -284,6 +284,7 @@ final class ExampleUITests: XCTestCase {
         app.tables.staticTexts["Yes"].tap()
         app.tables.staticTexts["Chocolate"].tap()
         app.tables.staticTexts["Sprinkles"].tap()
+        app.tables.staticTexts["Marshmallows"].tap()
         app.buttons["Next"].tap()
 
         // Finish survey

--- a/Example/ExampleUITests/ExampleUITests.swift
+++ b/Example/ExampleUITests/ExampleUITests.swift
@@ -10,6 +10,7 @@
 // swiftlint:disable file_length
 import XCTest
 
+
 // We disable type body length rule because this is a test
 // swiftlint:disable:next type_body_length
 final class ExampleUITests: XCTestCase {
@@ -492,14 +493,17 @@ final class ExampleUITests: XCTestCase {
         app.buttons["Next"].tap()
 
         // First result screen appears if at least one answer is correct.
+        sleep(1)
         XCTAssert(app.buttons["Next"].waitForExistence(timeout: 2))
         app.buttons["Next"].tap()
 
         // Second result screen appears if all answers are correct.
+        sleep(1)
         XCTAssert(app.buttons["Next"].waitForExistence(timeout: 2))
         app.buttons["Next"].tap()
 
         // Now the completion screen will appear with a "Done" button that we can tap
+        sleep(1)
         XCTAssert(app.buttons["Done"].waitForExistence(timeout: 2))
         app.buttons["Done"].tap()
 
@@ -525,10 +529,12 @@ final class ExampleUITests: XCTestCase {
         app.buttons["Next"].tap()
 
         // Only one result screen should appear.
+        sleep(1)
         XCTAssert(app.buttons["Next"].waitForExistence(timeout: 2))
         app.buttons["Next"].tap()
 
         // Now the completion screen should appear.
+        sleep(1)
         XCTAssert(app.buttons["Done"].waitForExistence(timeout: 2))
         app.buttons["Done"].tap()
     }

--- a/Example/ExampleUITests/ExampleUITests.swift
+++ b/Example/ExampleUITests/ExampleUITests.swift
@@ -133,6 +133,8 @@ final class ExampleUITests: XCTestCase {
         doneButton.tap()
 
         // Open context menu and view results
+        sleep(1)
+        XCTAssert(containedValueSetExampleButton.waitForExistence(timeout: 2))
         containedValueSetExampleButton.press(forDuration: 1.0)
         app.collectionViews.buttons["View Responses"].tap()
 

--- a/Sources/FHIRQuestionnaires/Resources/FormExample.json
+++ b/Sources/FHIRQuestionnaires/Resources/FormExample.json
@@ -62,7 +62,7 @@
         },
         {
           "linkId": "5ad9456c-1451-4190-fff5-3fd71545a591",
-          "type": "choice",
+          "type": "open-choice",
           "text": "What is your favorite flavor of ice cream?",
           "required": true,
           "answerOption": [

--- a/Sources/FHIRQuestionnaires/Resources/FormExample.json
+++ b/Sources/FHIRQuestionnaires/Resources/FormExample.json
@@ -105,6 +105,20 @@
           "type": "choice",
           "text": "What is your favorite topping on ice cream?",
           "required": false,
+          "extension": [
+              {
+                "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                "valueCodeableConcept": {
+                  "coding": [
+                    {
+                      "system": "http://hl7.org/fhir/questionnaire-item-control",
+                      "code": "multi-select",
+                      "display": "Multi select"
+                    }
+                  ]
+                }
+              },
+          ],
           "answerOption": [
             {
               "valueCoding": {

--- a/Sources/FHIRQuestionnaires/Resources/FormExample.json
+++ b/Sources/FHIRQuestionnaires/Resources/FormExample.json
@@ -112,8 +112,8 @@
                   "coding": [
                     {
                       "system": "http://hl7.org/fhir/questionnaire-item-control",
-                      "code": "multi-select",
-                      "display": "Multi select"
+                      "code": "check-box",
+                      "display": "Checkbox"
                     }
                   ]
                 }

--- a/Sources/ResearchKitOnFHIR/FHIRToResearchKit/QuestionnaireItem+ResearchKit.swift
+++ b/Sources/ResearchKitOnFHIR/FHIRToResearchKit/QuestionnaireItem+ResearchKit.swift
@@ -152,7 +152,7 @@ extension QuestionnaireItem {
                 throw FHIRToResearchKitConversionError.noOptions
             }
             var choiceAnswerStyle = ORKChoiceAnswerStyle.singleChoice
-            if itemControl == "multi-select" {
+            if itemControl == "check-box" {
                 choiceAnswerStyle = .multipleChoice
             }
             return ORKTextChoiceAnswerFormat(style: choiceAnswerStyle, textChoices: answerOptions)

--- a/Sources/ResearchKitOnFHIR/FHIRToResearchKit/QuestionnaireItem+ResearchKit.swift
+++ b/Sources/ResearchKitOnFHIR/FHIRToResearchKit/QuestionnaireItem+ResearchKit.swift
@@ -151,6 +151,9 @@ extension QuestionnaireItem {
             guard !answerOptions.isEmpty else {
                 throw FHIRToResearchKitConversionError.noOptions
             }
+            if itemControl == "multi-select" {
+                return ORKTextChoiceAnswerFormat(style: ORKChoiceAnswerStyle.multipleChoice, textChoices: answerOptions)
+            }
             return ORKTextChoiceAnswerFormat(style: ORKChoiceAnswerStyle.singleChoice, textChoices: answerOptions)
         case .date:
             return ORKDateAnswerFormat(style: ORKDateAnswerStyle.date)

--- a/Sources/ResearchKitOnFHIR/FHIRToResearchKit/QuestionnaireItem+ResearchKit.swift
+++ b/Sources/ResearchKitOnFHIR/FHIRToResearchKit/QuestionnaireItem+ResearchKit.swift
@@ -151,10 +151,11 @@ extension QuestionnaireItem {
             guard !answerOptions.isEmpty else {
                 throw FHIRToResearchKitConversionError.noOptions
             }
+            var choiceAnswerStyle = ORKChoiceAnswerStyle.singleChoice
             if itemControl == "multi-select" {
-                return ORKTextChoiceAnswerFormat(style: ORKChoiceAnswerStyle.multipleChoice, textChoices: answerOptions)
+                choiceAnswerStyle = .multipleChoice
             }
-            return ORKTextChoiceAnswerFormat(style: ORKChoiceAnswerStyle.singleChoice, textChoices: answerOptions)
+            return ORKTextChoiceAnswerFormat(style: choiceAnswerStyle, textChoices: answerOptions)
         case .date:
             return ORKDateAnswerFormat(style: ORKDateAnswerStyle.date)
         case .dateTime:

--- a/Sources/ResearchKitOnFHIR/ResearchKitToFHIR/ORKTaskResult+FHIR.swift
+++ b/Sources/ResearchKitOnFHIR/ResearchKitToFHIR/ORKTaskResult+FHIR.swift
@@ -127,22 +127,17 @@ extension ORKTaskResult {
         var responses: [QuestionnaireResponseItemAnswer.ValueX] = []
         
         for answer in answerArray {
-            // If the result is a string (i.e. the user selected the "other" option and entered a free-text answer), return a String
-            if let answerString = answer as? String {
+            // Check if answer can be treated as a ValueCoding first
+            if let valueCodingString = answer as? String, let valueCoding = ValueCoding(rawValue: valueCodingString) {
+                let coding = Coding(
+                    code: FHIRPrimitive(FHIRString(valueCoding.code)),
+                    system: FHIRPrimitive(FHIRURI(stringLiteral: valueCoding.system))
+                )
+                responses += [.coding(coding)]
+            } else if let answerString = answer as? String {
+                // If not, fall back to treating it as a regular string
                 responses += [.string(FHIRPrimitive(FHIRString(answerString)))]
             }
-            
-            // If the result is a dictionary containing a code and system, return a Coding
-            guard let valueCodingString = answer as? String,
-                  let valueCoding = ValueCoding(rawValue: valueCodingString) else {
-                continue
-            }
-            
-            let coding = Coding(
-                code: FHIRPrimitive(FHIRString(valueCoding.code)),
-                system: FHIRPrimitive(FHIRURI(stringLiteral: valueCoding.system))
-            )
-            responses += [.coding(coding)]
         }
         
         return responses

--- a/Sources/ResearchKitOnFHIR/ResearchKitToFHIR/ORKTaskResult+FHIR.swift
+++ b/Sources/ResearchKitOnFHIR/ResearchKitToFHIR/ORKTaskResult+FHIR.swift
@@ -51,17 +51,15 @@ extension ORKTaskResult {
 
     private func createResponse(_ result: ORKResult) -> QuestionnaireResponseItem {
         let response = QuestionnaireResponseItem(linkId: FHIRPrimitive(FHIRString(result.identifier)))
-        
         var responseAnswers: [QuestionnaireResponseItemAnswer] = []
         
         switch result {
         case let result as ORKBooleanQuestionResult:
             appendResponseAnswer(createBooleanResponse(result), to: &responseAnswers)
         case let result as ORKChoiceQuestionResult:
-            if let values = createChoiceResponse(result) {
-                for value in values {
-                    appendResponseAnswer(value, to: &responseAnswers)
-                }
+            let values = createChoiceResponse(result)
+            for value in values {
+                appendResponseAnswer(value, to: &responseAnswers)
             }
         case let result as ORKFileResult:
             appendResponseAnswer(createAttachmentResponse(result), to: &responseAnswers)
@@ -121,9 +119,9 @@ extension ORKTaskResult {
         return .string(FHIRPrimitive(FHIRString(text)))
     }
     
-    private func createChoiceResponse(_ result: ORKChoiceQuestionResult) -> [QuestionnaireResponseItemAnswer.ValueX]? {
+    private func createChoiceResponse(_ result: ORKChoiceQuestionResult) -> [QuestionnaireResponseItemAnswer.ValueX] {
         guard let answerArray = result.answer as? NSArray, answerArray.count > 0 else { // swiftlint:disable:this empty_count
-            return nil
+            return []
         }
         
         var responses: [QuestionnaireResponseItemAnswer.ValueX] = []

--- a/Tests/ResearchKitOnFHIRTests/ResearchKitToFHIRTests.swift
+++ b/Tests/ResearchKitOnFHIRTests/ResearchKitToFHIRTests.swift
@@ -182,7 +182,7 @@ final class ResearchKitToFHIRTests: XCTestCase {
         XCTAssertEqual(testValue, responseValue)
     }
     
-    func testChoiceResponse() {
+    func testSingleChoiceResponse() {
         let testValue = ValueCoding(code: "testCode", system: "http://biodesign.stanford.edu/test-system")
         
         let choiceResult = ORKChoiceQuestionResult(identifier: "choiceResult")


### PR DESCRIPTION
<!--

This source file is part of the Stanford Biodesign Digital Health Group open-source organization

SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)

SPDX-License-Identifier: MIT

-->

# Add support for multiple selection questions

## :recycle: Current situation & Problem
Currently, only a single choice can be selected for a multiple choice question. However, many questionnaires have questions that allow users to select multiple options simultaneously. This answer format is supported by the HL7 SDC Implementation Guide using the `check-box` UI control code with the `questionnaire-item-control` extension.

## :bulb: Proposed solution
Updates `ResearchKitOnFHIR` to recognize the `check-box` code when using the `questionnaire-item-control` extension and render a question that allows the user to select multiple choices. All selected choices are included as answers in the resulting `QuestionnaireResponse`.

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [X] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).

