### PR TITLE
Adding display parameter to ValueCoding

### DIFF
--- a/Sources/ResearchKitOnFHIR/FHIRToResearchKit/NavigationRules.swift
+++ b/Sources/ResearchKitOnFHIR/FHIRToResearchKit/NavigationRules.swift
@@ -90,7 +90,7 @@ extension Coding {
             return nil
         }
         
-        let expectedAnswer = ValueCoding(code: code, system: system)
+        let expectedAnswer = ValueCoding(code: code, system: system, display: display?.value?.string)
         
         let predicate = ORKResultPredicate.predicateForChoiceQuestionResult(
             with: resultSelector,

--- a/Sources/ResearchKitOnFHIR/FHIRToResearchKit/QuestionnaireItem+ResearchKit.swift
+++ b/Sources/ResearchKitOnFHIR/FHIRToResearchKit/QuestionnaireItem+ResearchKit.swift
@@ -226,7 +226,7 @@ extension QuestionnaireItem {
                       let system = valueSet?.compose?.include.first?.system?.value?.url.absoluteString else {
                     continue
                 }
-                let valueCoding = ValueCoding(code: code, system: system)
+                let valueCoding = ValueCoding(code: code, system: system, display: display)
                 let choice = ORKTextChoice(text: display, value: valueCoding.rawValue as NSSecureCoding & NSCopying & NSObjectProtocol)
                 choices.append(choice)
             }
@@ -244,7 +244,7 @@ extension QuestionnaireItem {
                       let system = coding.system?.value?.url.absoluteString else {
                     continue
                 }
-                let valueCoding = ValueCoding(code: code, system: system)
+                let valueCoding = ValueCoding(code: code, system: system, display: display)
                 let choice = ORKTextChoice(text: display, value: valueCoding.rawValue as NSSecureCoding & NSCopying & NSObjectProtocol)
                 choices.append(choice)
             }
@@ -252,7 +252,7 @@ extension QuestionnaireItem {
             if openChoice {
                 // If the `QuestionnaireItemType` is `open-choice`, allow user to enter in their own free-text answer.
                 let otherChoiceText = NSLocalizedString("Other", comment: "")
-                let otherChoiceResult = ValueCoding(code: "other", system: "other")
+                let otherChoiceResult = ValueCoding(code: "other", system: "other", display: otherChoiceText)
                 let otherChoice = ORKTextChoiceOther.choice(
                     withText: otherChoiceText,
                     detailText: nil,

--- a/Sources/ResearchKitOnFHIR/ResearchKitToFHIR/ORKTaskResult+FHIR.swift
+++ b/Sources/ResearchKitOnFHIR/ResearchKitToFHIR/ORKTaskResult+FHIR.swift
@@ -129,8 +129,10 @@ extension ORKTaskResult {
         for answer in answerArray {
             // Check if answer can be treated as a ValueCoding first
             if let valueCodingString = answer as? String, let valueCoding = ValueCoding(rawValue: valueCodingString) {
+                
                 let coding = Coding(
                     code: FHIRPrimitive(FHIRString(valueCoding.code)),
+                    display: valueCoding.display.map { FHIRPrimitive(FHIRString($0)) },
                     system: FHIRPrimitive(FHIRURI(stringLiteral: valueCoding.system))
                 )
                 responses += [.coding(coding)]

--- a/Sources/ResearchKitOnFHIR/ValueCoding/ValueCoding.swift
+++ b/Sources/ResearchKitOnFHIR/ValueCoding/ValueCoding.swift
@@ -13,12 +13,13 @@ struct ValueCoding: Equatable, Codable, RawRepresentable {
     enum CodingKeys: String, CodingKey {
         case code
         case system
+        case display
     }
     
     
     let code: String
     let system: String
-    
+    let display: String?
     
     var rawValue: String {
         guard let data = try? JSONEncoder().encode(self) else {
@@ -29,9 +30,10 @@ struct ValueCoding: Equatable, Codable, RawRepresentable {
     }
     
     
-    init(code: String, system: String) {
+    init(code: String, system: String, display: String?) {
         self.code = code
         self.system = system
+        self.display = display
     }
     
     init?(rawValue: String) {
@@ -47,12 +49,13 @@ struct ValueCoding: Equatable, Codable, RawRepresentable {
         let values = try decoder.container(keyedBy: CodingKeys.self)
         self.code = try values.decode(String.self, forKey: .code)
         self.system = try values.decode(String.self, forKey: .system)
+        self.display = try values.decodeIfPresent(String.self, forKey: .display)
     }
-    
     
     func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(code, forKey: .code)
         try container.encode(system, forKey: .system)
+        try container.encode(display, forKey: .display)
     }
 }

--- a/Tests/ResearchKitOnFHIRTests/ResearchKitToFHIRTests.swift
+++ b/Tests/ResearchKitOnFHIRTests/ResearchKitToFHIRTests.swift
@@ -183,7 +183,7 @@ final class ResearchKitToFHIRTests: XCTestCase {
     }
     
     func testSingleChoiceResponse() {
-        let testValue = ValueCoding(code: "testCode", system: "http://biodesign.stanford.edu/test-system")
+        let testValue = ValueCoding(code: "testCode", system: "http://biodesign.stanford.edu/test-system", display: "Test Code")
         
         let choiceResult = ORKChoiceQuestionResult(identifier: "choiceResult")
         choiceResult.choiceAnswers = [testValue.rawValue as NSSecureCoding & NSCopying & NSObjectProtocol]
@@ -198,12 +198,13 @@ final class ResearchKitToFHIRTests: XCTestCase {
         switch answer {
         case let .coding(coding):
             guard let code = coding.code?.value?.string,
+                  let display = coding.display?.value?.string,
                   let system = coding.system?.value?.url.absoluteString else {
                 XCTFail("Could not extract the code and system from the coding.")
                 return
             }
             
-            let valueCoding = ValueCoding(code: code, system: system)
+            let valueCoding = ValueCoding(code: code, system: system, display: display)
             XCTAssertEqual(testValue, valueCoding)
             
         default:
@@ -214,8 +215,8 @@ final class ResearchKitToFHIRTests: XCTestCase {
     
     func testMultipleChoiceResponse() {
         let testValues = [
-            ValueCoding(code: "testCode1", system: "http://biodesign.stanford.edu/test-system"),
-            ValueCoding(code: "testCode2", system: "http://biodesign.stanford.edu/test-system")
+            ValueCoding(code: "testCode1", system: "http://biodesign.stanford.edu/test-system", display: "Test Code 1"),
+            ValueCoding(code: "testCode2", system: "http://biodesign.stanford.edu/test-system", display: "Test Code 2"),
         ]
         
         let choiceResult = ORKChoiceQuestionResult(identifier: "choiceResult")
@@ -240,12 +241,13 @@ final class ResearchKitToFHIRTests: XCTestCase {
             switch answer {
             case let .coding(coding):
                 guard let code = coding.code?.value?.string,
+                      let display = coding.display?.value?.string,
                       let system = coding.system?.value?.url.absoluteString else {
                     XCTFail("Could not extract the code and system from the coding.")
                     return
                 }
                 
-                let valueCoding = ValueCoding(code: code, system: system)
+                let valueCoding = ValueCoding(code: code, system: system, display: display)
                 XCTAssertEqual(testValues[index], valueCoding)
                 
             default:


### PR DESCRIPTION
# Adding display parameter to ValueCoding

## Currently `ValueCoding` doesn't contain the display property defined by  [FHIR standard](https://www.hl7.org/fhir/datatypes.html#Coding)
This is a limitation in case the response of the questionnaire is presented on other platforms like FE or Android which use this property for displaying the text of the answer.


## :gear: Release Notes 
* property `display` was added to the `ValueCoding` structure.


## :books: Documentation
* The FHIR standard defines a display attribute under the Coding 
* This property was unfortunately missing in the current implementation of `ValueCoding`
* The cardinality of the attribute is according to [FHIR](https://www.hl7.org/fhir/datatypes.html#Coding) 0..1
* Because of this, the property is defined as an `Optional<String>` in Swift.
* In case this property is missing, decoding will not fail thanks to `decodeIfPresent`


## :white_check_mark: Testing
* Unit tests have been updated and are successfully passing.


### Code of Conduct & Contributing Guidelines 
By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [ ] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
