### PR TITLE
Support placeholder text, multiline text fields, text features and labels

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -141,8 +141,6 @@ only_rules:
   - implicitly_unwrapped_optional
   # Identifiers should use inclusive language that avoids discrimination against groups of people based on race, gender, or socioeconomic status
   - inclusive_language
-  # If defer is at the end of its parent scope, it will be executed right where it is anyway.
-  - inert_defer
   # Prefer using Set.isDisjoint(with:) over Set.intersection(_:).isEmpty.
   - is_disjoint
   # Discouraged explicit usage of the default separator.
@@ -329,8 +327,6 @@ only_rules:
   - unowned_variable_capture
   # Catch statements should not declare error variables without type casting.
   - untyped_error_in_catch
-  # Unused reference in a capture list should be removed.
-  - unused_capture_list
   # Unused parameter in a closure should be replaced with _.
   - unused_closure_parameter
   # Unused control flow label should be removed.

--- a/Sources/ResearchKitOnFHIR/FHIRExtensions/FHIRExtensions.swift
+++ b/Sources/ResearchKitOnFHIR/FHIRExtensions/FHIRExtensions.swift
@@ -13,7 +13,7 @@ import OSLog
 
 
 extension QuestionnaireItem {
-    private static logger = Logger(subsystem: "edu.stanford.spezi.researchkit-on-fhir", category: "FHIRExtensions")
+    private static let logger = Logger(subsystem: "edu.stanford.spezi.researchkit-on-fhir", category: "FHIRExtensions")
 
     /// Supported FHIR extensions for QuestionnaireItems
     private enum SupportedExtensions {

--- a/Sources/ResearchKitOnFHIR/FHIRExtensions/FHIRExtensions.swift
+++ b/Sources/ResearchKitOnFHIR/FHIRExtensions/FHIRExtensions.swift
@@ -9,9 +9,12 @@
 import Foundation
 import ModelsR4
 import SwiftUI
+import OSLog
 
 
 extension QuestionnaireItem {
+    private static logger = Logger(subsystem: "edu.stanford.spezi.researchkit-on-fhir", category: "FHIRExtensions")
+
     /// Supported FHIR extensions for QuestionnaireItems
     private enum SupportedExtensions {
         static let itemControl = "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl"
@@ -27,6 +30,10 @@ extension QuestionnaireItem {
         static let validationMessage = "http://biodesign.stanford.edu/fhir/StructureDefinition/validationtext"
 #if os(iOS) || os(visionOS)
         static let keyboardType = "http://biodesign.stanford.edu/fhir/StructureDefinition/ios-keyboardtype"
+#endif
+#if os(iOS) || os(visionOS) || os(tvOS)
+        static let textContentType = "http://biodesign.stanford.edu/fhir/StructureDefinition/ios-textcontenttype"
+        static let autocapitalizationType = "http://biodesign.stanford.edu/fhir/StructureDefinition/ios-autocapitalizationType"
 #endif
     }
 
@@ -198,6 +205,131 @@ extension QuestionnaireItem {
         case "asciiCapableNumberPad":
             return .asciiCapableNumberPad
         default:
+            Self.logger.warning("Encountered unexpected keyboardType in FHIR extension: \(keyboardTypeString)")
+            return nil
+        }
+    }
+#endif
+#if os(iOS) || os(visionOS) || os(tvOS)
+    var autocapitalizationType: UITextAutocapitalizationType? {
+        guard let autocapitalizationTypeExtension = getExtensionInQuestionnaireItem(url: SupportedExtensions.autocapitalizationType),
+              case let .string(autocapitalizationTypeValue) = autocapitalizationTypeExtension.value,
+              let autocapitalizationTypeString = autocapitalizationTypeValue.value?.string else {
+            return nil
+        }
+
+        switch autocapitalizationTypeString {
+        case "none":
+            return UITextAutocapitalizationType.none
+        case "words":
+            return .words
+        case "sentences":
+            return .sentences
+        case "allCharacters":
+            return .allCharacters
+        default:
+            Self.logger.warning("Encountered unexpected autocapitalizationType in FHIR extension: \(autocapitalizationTypeString)")
+            return nil
+        }
+    }
+
+    var textContentType: UITextContentType? {
+        guard let contentTypeExtension = getExtensionInQuestionnaireItem(url: SupportedExtensions.keyboardType),
+              case let .string(contentTypeValue) = contentTypeExtension.value,
+              let contentTypeString = contentTypeValue.value?.string else {
+            return nil
+        }
+
+        switch contentTypeString {
+        case "URL":
+            return .URL
+        case "namePrefix":
+            return .namePrefix
+        case "name":
+            return .name
+        case "nameSuffix":
+            return .nameSuffix
+        case "givenName":
+            return .givenName
+        case "middleName":
+            return .middleName
+        case "familyName":
+            return .familyName
+        case "nickname":
+            return .nickname
+        case "organizationName":
+            return .organizationName
+        case "jobTitle":
+            return .jobTitle
+        case "location":
+            return .location
+        case "fullStreetAddress":
+            return .fullStreetAddress
+        case "streetAddressLine1":
+            return .streetAddressLine1
+        case "streetAddressLine2":
+            return .streetAddressLine2
+        case "addressCity":
+            return .addressCity
+        case "addressCityAndState":
+            return .addressCityAndState
+        case "addressState":
+            return .addressState
+        case "postalCode":
+            return .postalCode
+        case "sublocality":
+            return .sublocality
+        case "countryName":
+            return .countryName
+        case "username":
+            return .username
+        case "password":
+            return .password
+        case "newPassword":
+            return .newPassword
+        case "oneTimeCode":
+            return .oneTimeCode
+        case "emailAddress":
+            return .emailAddress
+        case "telephoneNumber":
+            return .telephoneNumber
+        case "creditCardNumber":
+            return .creditCardNumber
+        case "dateTime":
+            return .dateTime
+        case "flightNumber":
+            return .flightNumber
+        case "shipmentTrackingNumber":
+            return .shipmentTrackingNumber
+        default:
+            if #available(iOS 17, visionOS 1, tvOS 17, *) {
+                switch contentTypeString {
+                case "creditCardExpiration":
+                    return .creditCardExpiration
+                case "creditCardExpirationMonth":
+                    return .creditCardExpirationMonth
+                case "creditCardExpirationYear":
+                    return .creditCardExpirationYear
+                case "creditCardSecurityCode":
+                    return .creditCardSecurityCode
+                case "creditCardType":
+                    return .creditCardType
+                case "creditCardName":
+                    return .creditCardName
+                case "creditCardGivenName":
+                    return .creditCardGivenName
+                case "creditCardMiddleName":
+                    return .creditCardMiddleName
+                case "creditCardFamilyName":
+                    return .creditCardFamilyName
+                case "birthdate":
+                    return .birthdate
+                default:
+                    break
+                }
+            }
+
+            Self.logger.warning("Encountered unexpected textContentType in FHIR extension: \(contentTypeString)")
             return nil
         }
     }

--- a/Sources/ResearchKitOnFHIR/FHIRExtensions/FHIRExtensions.swift
+++ b/Sources/ResearchKitOnFHIR/FHIRExtensions/FHIRExtensions.swift
@@ -8,13 +8,11 @@
 
 import Foundation
 import ModelsR4
-import SwiftUI
 import OSLog
+import SwiftUI
 
 
 extension QuestionnaireItem {
-    private static let logger = Logger(subsystem: "edu.stanford.spezi.researchkit-on-fhir", category: "FHIRExtensions")
-
     /// Supported FHIR extensions for QuestionnaireItems
     private enum SupportedExtensions {
         static let itemControl = "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl"
@@ -36,6 +34,8 @@ extension QuestionnaireItem {
         static let autocapitalizationType = "http://biodesign.stanford.edu/fhir/StructureDefinition/ios-autocapitalizationType"
 #endif
     }
+
+    private static let logger = Logger(subsystem: "edu.stanford.spezi.researchkit-on-fhir", category: "FHIRExtensions")
 
     /// Is the question hidden
     /// - Returns: A boolean representing whether the question should be shown to the user

--- a/Sources/ResearchKitOnFHIR/FHIRExtensions/FHIRExtensions.swift
+++ b/Sources/ResearchKitOnFHIR/FHIRExtensions/FHIRExtensions.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 import ModelsR4
+import SwiftUI
 
 
 extension QuestionnaireItem {
@@ -17,14 +18,18 @@ extension QuestionnaireItem {
         static let questionnaireUnit = "http://hl7.org/fhir/StructureDefinition/questionnaire-unit"
         static let regex = "http://hl7.org/fhir/StructureDefinition/regex"
         static let sliderStepValue = "http://hl7.org/fhir/StructureDefinition/questionnaire-sliderStepValue"
-        static let validationMessage = "http://biodesign.stanford.edu/fhir/StructureDefinition/validationtext"
         static let maxDecimalPlaces = "http://hl7.org/fhir/StructureDefinition/maxDecimalPlaces"
         static let minValue = "http://hl7.org/fhir/StructureDefinition/minValue"
         static let maxValue = "http://hl7.org/fhir/StructureDefinition/maxValue"
         static let hidden = "http://hl7.org/fhir/StructureDefinition/questionnaire-hidden"
         static let entryFormat = "http://hl7.org/fhir/StructureDefinition/entryFormat"
+
+        static let validationMessage = "http://biodesign.stanford.edu/fhir/StructureDefinition/validationtext"
+#if os(iOS) || os(visionOS)
+        static let keyboardType = "http://biodesign.stanford.edu/fhir/StructureDefinition/ios-keyboardtype"
+#endif
     }
-    
+
     /// Is the question hidden
     /// - Returns: A boolean representing whether the question should be shown to the user
     var hidden: Bool {
@@ -157,6 +162,46 @@ extension QuestionnaireItem {
         }
         return placeholderText
     }
+
+
+#if os(iOS) || os(visionOS)
+    var keyboardType: UIKeyboardType? {
+        guard let keyboardTypeExtension = getExtensionInQuestionnaireItem(url: SupportedExtensions.keyboardType),
+              case let .string(keyboardTypeValue) = keyboardTypeExtension.value,
+              let keyboardTypeString = keyboardTypeValue.value?.string else {
+            return nil
+        }
+
+        switch keyboardTypeString {
+        case "default":
+            return .default
+        case "asciiCapable":
+            return .asciiCapable
+        case "numbersAndPunctuation":
+            return .numbersAndPunctuation
+        case "URL":
+            return .URL
+        case "numberPad":
+            return .numberPad
+        case "phonePad":
+            return .phonePad
+        case "namePhonePad":
+            return .namePhonePad
+        case "emailAddress":
+            return .emailAddress
+        case "decimalPad":
+            return .decimalPad
+        case "twitter":
+            return .twitter
+        case "webSearch":
+            return .webSearch
+        case "asciiCapableNumberPad":
+            return .asciiCapableNumberPad
+        default:
+            return nil
+        }
+    }
+#endif
 
     
     /// Checks this QuestionnaireItem for an extension matching the given URL and then return it if it exists.

--- a/Sources/ResearchKitOnFHIR/FHIRExtensions/FHIRExtensions.swift
+++ b/Sources/ResearchKitOnFHIR/FHIRExtensions/FHIRExtensions.swift
@@ -22,6 +22,7 @@ extension QuestionnaireItem {
         static let minValue = "http://hl7.org/fhir/StructureDefinition/minValue"
         static let maxValue = "http://hl7.org/fhir/StructureDefinition/maxValue"
         static let hidden = "http://hl7.org/fhir/StructureDefinition/questionnaire-hidden"
+        static let entryFormat = "http://hl7.org/fhir/StructureDefinition/entryFormat"
     }
     
     /// Is the question hidden
@@ -147,7 +148,16 @@ extension QuestionnaireItem {
         }
         return stringMessage
     }
-    
+
+    var placeholderText: String? {
+        guard let entryFormatExtension = getExtensionInQuestionnaireItem(url: SupportedExtensions.entryFormat),
+              case let .string(placeholder) = entryFormatExtension.value,
+              let placeholderText = placeholder.value?.string else {
+            return nil
+        }
+        return placeholderText
+    }
+
     
     /// Checks this QuestionnaireItem for an extension matching the given URL and then return it if it exists.
     /// - Parameters:

--- a/Sources/ResearchKitOnFHIR/FHIRExtensions/FHIRExtensions.swift
+++ b/Sources/ResearchKitOnFHIR/FHIRExtensions/FHIRExtensions.swift
@@ -25,13 +25,14 @@ extension QuestionnaireItem {
         static let hidden = "http://hl7.org/fhir/StructureDefinition/questionnaire-hidden"
         static let entryFormat = "http://hl7.org/fhir/StructureDefinition/entryFormat"
 
-        static let validationMessage = "http://biodesign.stanford.edu/fhir/StructureDefinition/validationtext"
+        static let validationMessageLegacy = "http://biodesign.stanford.edu/fhir/StructureDefinition/validationtext"
+        static let validationMessage = "http://bdh.stanford.edu/fhir/StructureDefinition/validationtext"
 #if os(iOS) || os(visionOS)
-        static let keyboardType = "http://biodesign.stanford.edu/fhir/StructureDefinition/ios-keyboardtype"
+        static let keyboardType = "http://bdh.stanford.edu/fhir/StructureDefinition/ios-keyboardtype"
 #endif
 #if os(iOS) || os(visionOS) || os(tvOS)
-        static let textContentType = "http://biodesign.stanford.edu/fhir/StructureDefinition/ios-textcontenttype"
-        static let autocapitalizationType = "http://biodesign.stanford.edu/fhir/StructureDefinition/ios-autocapitalizationType"
+        static let textContentType = "http://bdh.stanford.edu/fhir/StructureDefinition/ios-textcontenttype"
+        static let autocapitalizationType = "http://bdh.stanford.edu/fhir/StructureDefinition/ios-autocapitalizationType"
 #endif
     }
 
@@ -153,7 +154,8 @@ extension QuestionnaireItem {
     /// The validation message for a question.
     /// - Returns: An optional `String` containing the validation message, if it exists.
     var validationMessage: String? {
-        guard let validationMessageExtension = getExtensionInQuestionnaireItem(url: SupportedExtensions.validationMessage),
+        guard let validationMessageExtension = getExtensionInQuestionnaireItem(url: SupportedExtensions.validationMessage)
+                ?? getExtensionInQuestionnaireItem(url: SupportedExtensions.validationMessageLegacy),
               case let .string(message) = validationMessageExtension.value,
               let stringMessage = message.value?.string else {
             return nil

--- a/Sources/ResearchKitOnFHIR/FHIRToResearchKit/QuestionnaireItem+ResearchKit.swift
+++ b/Sources/ResearchKitOnFHIR/FHIRToResearchKit/QuestionnaireItem+ResearchKit.swift
@@ -80,7 +80,7 @@ extension QuestionnaireItem {
         let step = ORKQuestionStep(identifier: identifier, title: title, question: questionText, answer: answer)
 
         if prefix != nil {
-            step.text = questionText
+            step.text = text?.value?.string
         }
 
         return step

--- a/Sources/ResearchKitOnFHIR/FHIRToResearchKit/QuestionnaireItem+ResearchKit.swift
+++ b/Sources/ResearchKitOnFHIR/FHIRToResearchKit/QuestionnaireItem+ResearchKit.swift
@@ -93,7 +93,7 @@ extension QuestionnaireItem {
         
         let formStep = ORKFormStep(identifier: id)
         formStep.title = title
-        formStep.text = text?.value?.string ?? "" // TODO: this cannot be modified!
+        formStep.text = text?.value?.string ?? ""
         var formItems = [ORKFormItem]()
 
         var containsRequiredSteps = false
@@ -117,10 +117,10 @@ extension QuestionnaireItem {
             
             formItems.append(formItem)
         }
-        
+
         formStep.formItems = formItems
         // if optional, the `Next` button will appear
-        formStep.isOptional = !containsRequiredSteps
+        formStep.isOptional = !containsRequiredSteps || !(required?.value?.bool == true)
         return formStep
     }
     

--- a/Sources/ResearchKitOnFHIR/FHIRToResearchKit/QuestionnaireItem+ResearchKit.swift
+++ b/Sources/ResearchKitOnFHIR/FHIRToResearchKit/QuestionnaireItem+ResearchKit.swift
@@ -169,7 +169,6 @@ extension QuestionnaireItem {
             }
             return ORKTextChoiceAnswerFormat(style: choiceAnswerStyle, textChoices: answerOptions)
         case .date:
-            // TODO: can we support the norvegian parsing? TODO: can we support that?
             return ORKDateAnswerFormat(
                 style: .date,
                 defaultDate: nil,
@@ -207,7 +206,11 @@ extension QuestionnaireItem {
             let answerFormat = ORKTextAnswerFormat(maximumLength: maximumLength)
 
             answerFormat.multipleLines = type.value == .text
-            // TODO: answerFormat.keyboardType = .phonePad
+#if os(iOS) || os(visionOS)
+            if let keyboardType {
+                answerFormat.keyboardType = keyboardType
+            }
+#endif
             // TODO: ??? answerFormat.autocapitalizationType = .words
             // TODO: ??? answerFormat.textContentType = .telephoneNumber
             answerFormat.placeholder = self.placeholderText

--- a/Sources/ResearchKitOnFHIR/FHIRToResearchKit/QuestionnaireItem+ResearchKit.swift
+++ b/Sources/ResearchKitOnFHIR/FHIRToResearchKit/QuestionnaireItem+ResearchKit.swift
@@ -37,6 +37,7 @@ extension Array where Element == QuestionnaireItem {
                 }
             case QuestionnaireItemType.group:
                 // Converts multiple questions in a group into a ResearchKit form step
+                // TODO: there is also a required property here???
                 if let groupStep = question.groupToORKFormStep(title: title, valueSets: valueSets) {
                     surveySteps.append(groupStep)
                 }
@@ -74,6 +75,8 @@ extension QuestionnaireItem {
         
         let questionText = text?.value?.string ?? ""
         let answer = try? self.toORKAnswerFormat(valueSets: valueSets)
+
+        // TODO: ability to change .text of the question step?
         return ORKQuestionStep(identifier: identifier, title: title, question: questionText, answer: answer)
     }
     
@@ -90,7 +93,7 @@ extension QuestionnaireItem {
         
         let formStep = ORKFormStep(identifier: id)
         formStep.title = title
-        formStep.text = text?.value?.string ?? ""
+        formStep.text = text?.value?.string ?? "" // TODO: this cannot be modified!
         var formItems = [ORKFormItem]()
 
         var containsRequiredSteps = false
@@ -166,6 +169,7 @@ extension QuestionnaireItem {
             }
             return ORKTextChoiceAnswerFormat(style: choiceAnswerStyle, textChoices: answerOptions)
         case .date:
+            // TODO: can we support the norvegian parsing? TODO: can we support that?
             return ORKDateAnswerFormat(
                 style: .date,
                 defaultDate: nil,
@@ -201,7 +205,13 @@ extension QuestionnaireItem {
         case .text, .string:
             let maximumLength = Int(maxLength?.value?.integer ?? 0)
             let answerFormat = ORKTextAnswerFormat(maximumLength: maximumLength)
-            
+
+            answerFormat.multipleLines = type.value == .text
+            // TODO: answerFormat.keyboardType = .phonePad
+            // TODO: ??? answerFormat.autocapitalizationType = .words
+            // TODO: ??? answerFormat.textContentType = .telephoneNumber
+            answerFormat.placeholder = self.placeholderText
+
             // Applies a regular expression for validation, if defined
             if let validationRegularExpression = validationRegularExpression {
                 answerFormat.validationRegularExpression = validationRegularExpression

--- a/Sources/ResearchKitOnFHIR/FHIRToResearchKit/QuestionnaireItem+ResearchKit.swift
+++ b/Sources/ResearchKitOnFHIR/FHIRToResearchKit/QuestionnaireItem+ResearchKit.swift
@@ -111,7 +111,7 @@ extension QuestionnaireItem {
             }
 
             if question.type == .display {
-                let formItem = ORKFormItem(sectionTitle: questionText)
+                let formItem = ORKFormItem(sectionTitle: questionText, detailText: question.placeholderText, learnMoreItem: nil, showsProgress: false)
                 formItems.append(formItem)
             } else if let answerFormat = try? question.toORKAnswerFormat(valueSets: valueSets) {
                 let formItem = ORKFormItem(identifier: questionId, text: questionText, answerFormat: answerFormat)
@@ -123,6 +123,7 @@ extension QuestionnaireItem {
                         containsRequiredSteps = true
                     }
                 }
+                formItem.placeholder = question.placeholderText
 
                 formItems.append(formItem)
             }
@@ -130,7 +131,7 @@ extension QuestionnaireItem {
 
         formStep.formItems = formItems
         // if optional, the `Next` button will appear
-        formStep.isOptional = !containsRequiredSteps || !(required?.value?.bool == true)
+        formStep.isOptional = !(containsRequiredSteps || required?.value?.bool == true)
         return formStep
     }
     


### PR DESCRIPTION
# Support placeholder text, multiline text fields, text features and labels

## :recycle: Current situation & Problem
Currently, FHIR questionnaires are not always mapped correctly to ResearchKit interface or some features are not able to be mapped at all. This includes things like multiline text fields and placeholder text event though supported by the questionnaire builder. Further, there are things that are not supported at all like setting the keyboard type which is very specific to iOS ui. We resolve this by introducing adequate extensions for these use cases.

## :gear: Release Notes 
* Take `required` property of "group"s into account when deciding to show the "Skip" button in a From.
* Allow to define section titles in forms through "display" steps in "group"s.
* Added extensions for autocapitalization, text content type and keyboard type.
* Fix rendering of multiline text fields
* Support our custom placeholder text extension
* Add support for the "prefix" (aka label) field.


## :white_check_mark: Testing
Tested within internal project.


### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
