### PR TITLE
relax FHIRModels version requirement

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -26,7 +26,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/StanfordBDHG/ResearchKit.git", .upToNextMinor(from: "3.0.1")),
-        .package(url: "https://github.com/apple/FHIRModels.git", from: "0.5.0"),
+        .package(url: "https://github.com/apple/FHIRModels.git", from: "0.7.0"),
         .package(url: "https://github.com/antlr/antlr4.git", from: "4.13.1")
     ] + swiftLintPackage(),
     targets: [

--- a/Package.swift
+++ b/Package.swift
@@ -26,7 +26,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/StanfordBDHG/ResearchKit.git", .upToNextMinor(from: "3.0.1")),
-        .package(url: "https://github.com/apple/FHIRModels.git", .upToNextMinor(from: "0.5.0")),
+        .package(url: "https://github.com/apple/FHIRModels.git", from: "0.5.0"),
         .package(url: "https://github.com/antlr/antlr4.git", from: "4.13.1")
     ] + swiftLintPackage(),
     targets: [


### PR DESCRIPTION
# relax FHIRModels version requirement

## :recycle: Current situation & Problem
relaxes the FHIRModels version requirement from upToNextMinor to upToNextMajor; replaces all with the more elegant from: overload.

## :gear: Release Notes
n/a

## :books: Documentation
n/a

## :white_check_mark: Testing
n/a

## :pencil: Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
