### PR TITLE
Lift ResearchKit to 3.1.1

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -25,7 +25,7 @@ let package = Package(
         .library(name: "FHIRQuestionnaires", targets: ["FHIRQuestionnaires"])
     ],
     dependencies: [
-        .package(url: "https://github.com/StanfordBDHG/ResearchKit.git", .upToNextMinor(from: "3.0.1")),
+        .package(url: "https://github.com/StanfordBDHG/ResearchKit.git", .upToNextMinor(from: "3.1.1")),
         .package(url: "https://github.com/apple/FHIRModels.git", from: "0.7.0"),
         .package(url: "https://github.com/antlr/antlr4.git", from: "4.13.1")
     ] + swiftLintPackage(),


### PR DESCRIPTION
# Lift ResearchKit to 3.1.1

Changed the ResearchKit dependency in `Package.swift` from `.upToNextMinor(from: "3.0.1")` to `.upToNextMinor(from: "3.1.1")` in order to use the latest stable release of RK which is 3.1.1. Currently apps using RKonFHIR are stuck on RK 3.0.3 which is not ideal because 3.1 and above have many bugfixes, new features, etc. There are no breaking changes.

### Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [X] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
