### PR TITLE
Coding: Regex pattern

### DIFF
--- a/Sources/ResearchKitOnFHIR/FHIRToResearchKit/NavigationRules.swift
+++ b/Sources/ResearchKitOnFHIR/FHIRToResearchKit/NavigationRules.swift
@@ -52,7 +52,7 @@ extension QuestionnaireItemEnableWhen {
         }
         let formSteps = task.steps.compactMap { $0 as? ORKFormStep }
         let stepIdentifier = formSteps
-            .first { $0.formItems?.contains(where: { $0.identifier == enableQuestionId }) != nil }?
+            .first { ($0.formItems ?? []).contains(where: { $0.identifier == enableQuestionId }) }?
             .identifier
         print("stepIdentifier", stepIdentifier)
         let resultSelector = ORKResultSelector(stepIdentifier: stepIdentifier, resultIdentifier: enableQuestionId)

--- a/Sources/ResearchKitOnFHIR/FHIRToResearchKit/NavigationRules.swift
+++ b/Sources/ResearchKitOnFHIR/FHIRToResearchKit/NavigationRules.swift
@@ -81,10 +81,13 @@ extension Coding {
         }
         
         let expectedAnswer = ValueCoding(code: code, system: system, display: display?.value?.string)
+        let pattern = expectedAnswer.patternForMatchingORKChoiceQuestionResult
         let predicate = ORKResultPredicate.predicateForChoiceQuestionResult(
             with: resultSelector,
-            matchingPattern: expectedAnswer.patternForMatchingORKChoiceQuestionResult
+            matchingPattern: pattern
         )
+        let stringValue = ValueCoding(code: code, system: system, display: display?.value?.string ?? "").rawValue
+        print("pattern matches itself:", try? NSRegularExpression(pattern: pattern).matches(in: stringValue, range: NSRange(location: 0, length: stringValue.count)))
         switch fhirOperator {
         case .equal:
             return predicate

--- a/Sources/ResearchKitOnFHIR/FHIRToResearchKit/NavigationRules.swift
+++ b/Sources/ResearchKitOnFHIR/FHIRToResearchKit/NavigationRules.swift
@@ -50,11 +50,7 @@ extension QuestionnaireItemEnableWhen {
               let fhirOperator = `operator`.value else {
             return nil
         }
-        let formSteps = task.steps.compactMap { $0 as? ORKFormStep }
-        let stepIdentifier = formSteps
-            .first { $0.formItems?.contains(where: { $0.identifier == enableQuestionId }) != nil }?
-            .identifier
-        let resultSelector = ORKResultSelector(stepIdentifier: stepIdentifier, resultIdentifier: enableQuestionId)
+        let resultSelector = ORKResultSelector(resultIdentifier: enableQuestionId)
         switch answer {
         case .coding(let coding):
             return try coding.predicate(with: resultSelector, operator: fhirOperator)

--- a/Sources/ResearchKitOnFHIR/FHIRToResearchKit/NavigationRules.swift
+++ b/Sources/ResearchKitOnFHIR/FHIRToResearchKit/NavigationRules.swift
@@ -52,7 +52,7 @@ extension QuestionnaireItemEnableWhen {
         }
         let formSteps = task.steps.compactMap { $0 as? ORKFormStep }
         let stepIdentifier = formSteps
-            .first { ($0.formItems ?? []).contains(where: { $0.identifier == enableQuestionId }) }?
+            .first { $0.formItems?.contains(where: { $0.identifier == enableQuestionId }) ?? false }?
             .identifier
         print("stepIdentifier", stepIdentifier)
         let resultSelector = ORKResultSelector(stepIdentifier: stepIdentifier, resultIdentifier: enableQuestionId)

--- a/Sources/ResearchKitOnFHIR/FHIRToResearchKit/NavigationRules.swift
+++ b/Sources/ResearchKitOnFHIR/FHIRToResearchKit/NavigationRules.swift
@@ -50,7 +50,12 @@ extension QuestionnaireItemEnableWhen {
               let fhirOperator = `operator`.value else {
             return nil
         }
-        let resultSelector = ORKResultSelector(resultIdentifier: enableQuestionId)
+        let formSteps = task.steps.compactMap { $0 as? ORKFormStep }
+        let stepIdentifier = formSteps
+            .first { $0.formItems?.contains(where: { $0.identifier == enableQuestionId }) != nil }?
+            .identifier
+        print("stepIdentifier", stepIdentifier)
+        let resultSelector = ORKResultSelector(stepIdentifier: stepIdentifier, resultIdentifier: enableQuestionId)
         switch answer {
         case .coding(let coding):
             return try coding.predicate(with: resultSelector, operator: fhirOperator)

--- a/Sources/ResearchKitOnFHIR/FHIRToResearchKit/NavigationRules.swift
+++ b/Sources/ResearchKitOnFHIR/FHIRToResearchKit/NavigationRules.swift
@@ -54,7 +54,6 @@ extension QuestionnaireItemEnableWhen {
         let stepIdentifier = formSteps
             .first { $0.formItems?.contains(where: { $0.identifier == enableQuestionId }) ?? false }?
             .identifier
-        print("stepIdentifier", stepIdentifier)
         let resultSelector = ORKResultSelector(stepIdentifier: stepIdentifier, resultIdentifier: enableQuestionId)
         switch answer {
         case .coding(let coding):
@@ -82,13 +81,10 @@ extension Coding {
         }
         
         let expectedAnswer = ValueCoding(code: code, system: system, display: display?.value?.string)
-        let pattern = expectedAnswer.patternForMatchingORKChoiceQuestionResult
         let predicate = ORKResultPredicate.predicateForChoiceQuestionResult(
             with: resultSelector,
-            matchingPattern: pattern
+            matchingPattern: expectedAnswer.patternForMatchingORKChoiceQuestionResult
         )
-        let stringValue = ValueCoding(code: code, system: system, display: display?.value?.string ?? "").rawValue
-        print("pattern matches itself:", try? NSRegularExpression(pattern: pattern).matches(in: stringValue, range: NSRange(location: 0, length: stringValue.count)))
         switch fhirOperator {
         case .equal:
             return predicate

--- a/Sources/ResearchKitOnFHIR/FHIRToResearchKit/QuestionnaireItem+ResearchKit.swift
+++ b/Sources/ResearchKitOnFHIR/FHIRToResearchKit/QuestionnaireItem+ResearchKit.swift
@@ -290,6 +290,7 @@ extension QuestionnaireItem {
                     continue
                 }
                 let valueCoding = ValueCoding(code: code, system: system, display: display)
+                print("Coding:", valueCoding.rawValue)
                 let choice = ORKTextChoice(text: display, value: valueCoding.rawValue as NSSecureCoding & NSCopying & NSObjectProtocol)
                 choices.append(choice)
             }
@@ -308,6 +309,7 @@ extension QuestionnaireItem {
                     continue
                 }
                 let valueCoding = ValueCoding(code: code, system: system, display: display)
+                print("Coding:", valueCoding.rawValue)
                 let choice = ORKTextChoice(text: display, value: valueCoding.rawValue as NSSecureCoding & NSCopying & NSObjectProtocol)
                 choices.append(choice)
             }

--- a/Sources/ResearchKitOnFHIR/FHIRToResearchKit/QuestionnaireItem+ResearchKit.swift
+++ b/Sources/ResearchKitOnFHIR/FHIRToResearchKit/QuestionnaireItem+ResearchKit.swift
@@ -290,7 +290,6 @@ extension QuestionnaireItem {
                     continue
                 }
                 let valueCoding = ValueCoding(code: code, system: system, display: display)
-                print("Coding:", valueCoding.rawValue)
                 let choice = ORKTextChoice(text: display, value: valueCoding.rawValue as NSSecureCoding & NSCopying & NSObjectProtocol)
                 choices.append(choice)
             }
@@ -309,7 +308,6 @@ extension QuestionnaireItem {
                     continue
                 }
                 let valueCoding = ValueCoding(code: code, system: system, display: display)
-                print("Coding:", valueCoding.rawValue)
                 let choice = ORKTextChoice(text: display, value: valueCoding.rawValue as NSSecureCoding & NSCopying & NSObjectProtocol)
                 choices.append(choice)
             }

--- a/Sources/ResearchKitOnFHIR/ValueCoding/ValueCoding.swift
+++ b/Sources/ResearchKitOnFHIR/ValueCoding/ValueCoding.swift
@@ -76,10 +76,13 @@ extension ValueCoding {
     /// we'd end up comparing one with a null `display` value against one with a non-null `display` value.
     /// (This would, obviously, cause the comparison to always fail, and conditional questions would never be enabled and presented to the patient.)
     var patternForMatchingORKChoiceQuestionResult: String { // swiftlint:disable:this identifier_name
+        let escapedCode = NSRegularExpression.escapedPattern(for: code)
+        let escapedSystem = NSRegularExpression.escapedPattern(for: system)
         if let display {
-            #"^\{"code":"\#(code)","display":"\#(display)","system":"\#(system)"\}$"#
+            let escapedDisplay = NSRegularExpression.escapedPattern(for: display)
+            return #"^\{"code":"\#(escapedCode)","display":"\#(escapedDisplay)","system":"\#(escapedSystem)"\}$"#
         } else {
-            #"^\{"code":"\#(code)","display":.*,"system":"\#(system)"\}$"#
+            return #"^\{"code":"\#(escapedCode)","display":.*,"system":"\#(escapedSystem)"\}$"#
         }
     }
 }

--- a/Sources/ResearchKitOnFHIR/ValueCoding/ValueCoding.swift
+++ b/Sources/ResearchKitOnFHIR/ValueCoding/ValueCoding.swift
@@ -77,19 +77,15 @@ extension ValueCoding {
     /// (This would, obviously, cause the comparison to always fail, and conditional questions would never be enabled and presented to the patient.)
     var patternForMatchingORKChoiceQuestionResult: String { // swiftlint:disable:this identifier_name
         if let display {
-            let pattern = #"^\{"code":\#(code.jsonRegexString),"display":\#(display.jsonRegexString),"system":\#(system.jsonRegexString)\}$"#
-            print("PATTERN", pattern)
-            return pattern
+            return #"^\{"code":\#(code.jsonPattern),"display":\#(display.jsonPattern),"system":\#(system.jsonPattern)\}$"#
         } else {
-            let pattern = #"^\{"code":\#(code.jsonRegexString),"display":.*,"system":\#(system.jsonRegexString)\}$"#
-            print("PATTERN", pattern)
-            return pattern
+            return #"^\{"code":\#(code.jsonPattern),"display":.*,"system":\#(system.jsonPattern)\}$"#
         }
     }
 }
 
 extension String {
-    fileprivate var jsonRegexString: String {
+    fileprivate var jsonPattern: String {
         do {
             let jsonData = try JSONEncoder().encode(self)
             guard let string = String(data: jsonData, encoding: .utf8) else {

--- a/Sources/ResearchKitOnFHIR/ValueCoding/ValueCoding.swift
+++ b/Sources/ResearchKitOnFHIR/ValueCoding/ValueCoding.swift
@@ -80,9 +80,13 @@ extension ValueCoding {
         let escapedSystem = NSRegularExpression.escapedPattern(for: system)
         if let display {
             let escapedDisplay = NSRegularExpression.escapedPattern(for: display)
-            return #"^\{"code":"\#(escapedCode)","display":"\#(escapedDisplay)","system":"\#(escapedSystem)"\}$"#
+            let pattern = #"^\{"code":"\#(escapedCode)","display":"\#(escapedDisplay)","system":"\#(escapedSystem)"\}$"#
+            print("PATTERN", pattern)
+            return pattern
         } else {
-            return #"^\{"code":"\#(escapedCode)","display":.*,"system":"\#(escapedSystem)"\}$"#
+            let pattern = #"^\{"code":"\#(escapedCode)","display":.*,"system":"\#(escapedSystem)"\}$"#
+            print("PATTERN", pattern)
+            return pattern
         }
     }
 }

--- a/Sources/ResearchKitOnFHIR/ValueCoding/ValueCoding.swift
+++ b/Sources/ResearchKitOnFHIR/ValueCoding/ValueCoding.swift
@@ -76,10 +76,13 @@ extension ValueCoding {
     /// we'd end up comparing one with a null `display` value against one with a non-null `display` value.
     /// (This would, obviously, cause the comparison to always fail, and conditional questions would never be enabled and presented to the patient.)
     var patternForMatchingORKChoiceQuestionResult: String { // swiftlint:disable:this identifier_name
-        let escapedCode = NSRegularExpression.escapedPattern(for: code)
-        let escapedSystem = NSRegularExpression.escapedPattern(for: system)
+        let jsonEncodedCode = (try? String(data: JSONEncoder().encode(code), encoding: .utf8)) ?? code
+        let escapedCode = NSRegularExpression.escapedPattern(for: jsonEncodedCode)
+        let jsonEncodedSystem = (try? String(data: JSONEncoder().encode(system), encoding: .utf8)) ?? system
+        let escapedSystem = NSRegularExpression.escapedPattern(for: jsonEncodedSystem)
         if let display {
-            let escapedDisplay = NSRegularExpression.escapedPattern(for: display)
+            let jsonEncodedDisplay = (try? String(data: JSONEncoder().encode(display), encoding: .utf8)) ?? display
+            let escapedDisplay = NSRegularExpression.escapedPattern(for: jsonEncodedDisplay)
             let pattern = #"^\{"code":"\#(escapedCode)","display":"\#(escapedDisplay)","system":"\#(escapedSystem)"\}$"#
             print("PATTERN", pattern)
             return pattern

--- a/Sources/ResearchKitOnFHIR/ValueCoding/ValueCoding.swift
+++ b/Sources/ResearchKitOnFHIR/ValueCoding/ValueCoding.swift
@@ -77,11 +77,11 @@ extension ValueCoding {
     /// (This would, obviously, cause the comparison to always fail, and conditional questions would never be enabled and presented to the patient.)
     var patternForMatchingORKChoiceQuestionResult: String { // swiftlint:disable:this identifier_name
         if let display {
-            let pattern = #"^\{"code":"\#(code.jsonRegexString)","display":"\#(display.jsonRegexString)","system":"\#(system.jsonRegexString)"\}$"#
+            let pattern = #"^\{"code":\#(code.jsonRegexString),"display":\#(display.jsonRegexString),"system":\#(system.jsonRegexString)\}$"#
             print("PATTERN", pattern)
             return pattern
         } else {
-            let pattern = #"^\{"code":"\#(code.jsonRegexString)","display":.*,"system":"\#(system.jsonRegexString)"\}$"#
+            let pattern = #"^\{"code":\#(code.jsonRegexString),"display":.*,"system":\#(system.jsonRegexString)\}$"#
             print("PATTERN", pattern)
             return pattern
         }
@@ -95,8 +95,7 @@ extension String {
             guard let string = String(data: jsonData, encoding: .utf8) else {
                 return NSRegularExpression.escapedPattern(for: self)
             }
-            let stringWithoutSurroundingQuotes = String(string.dropFirst().dropLast())
-            return NSRegularExpression.escapedPattern(for: stringWithoutSurroundingQuotes)
+            return NSRegularExpression.escapedPattern(for: string)
         } catch {
             return NSRegularExpression.escapedPattern(for: self)
         }

--- a/Sources/ResearchKitOnFHIR/ValueCoding/ValueCoding.swift
+++ b/Sources/ResearchKitOnFHIR/ValueCoding/ValueCoding.swift
@@ -76,20 +76,29 @@ extension ValueCoding {
     /// we'd end up comparing one with a null `display` value against one with a non-null `display` value.
     /// (This would, obviously, cause the comparison to always fail, and conditional questions would never be enabled and presented to the patient.)
     var patternForMatchingORKChoiceQuestionResult: String { // swiftlint:disable:this identifier_name
-        let jsonEncodedCode = (try? String(data: JSONEncoder().encode(code), encoding: .utf8)) ?? code
-        let escapedCode = NSRegularExpression.escapedPattern(for: jsonEncodedCode)
-        let jsonEncodedSystem = (try? String(data: JSONEncoder().encode(system), encoding: .utf8)) ?? system
-        let escapedSystem = NSRegularExpression.escapedPattern(for: jsonEncodedSystem)
         if let display {
-            let jsonEncodedDisplay = (try? String(data: JSONEncoder().encode(display), encoding: .utf8)) ?? display
-            let escapedDisplay = NSRegularExpression.escapedPattern(for: jsonEncodedDisplay)
-            let pattern = #"^\{"code":"\#(escapedCode)","display":"\#(escapedDisplay)","system":"\#(escapedSystem)"\}$"#
+            let pattern = #"^\{"code":"\#(code.jsonRegexString)","display":"\#(display.jsonRegexString)","system":"\#(system.jsonRegexString)"\}$"#
             print("PATTERN", pattern)
             return pattern
         } else {
-            let pattern = #"^\{"code":"\#(escapedCode)","display":.*,"system":"\#(escapedSystem)"\}$"#
+            let pattern = #"^\{"code":"\#(code.jsonRegexString)","display":.*,"system":"\#(system.jsonRegexString)"\}$"#
             print("PATTERN", pattern)
             return pattern
+        }
+    }
+}
+
+extension String {
+    fileprivate var jsonRegexString: String {
+        do {
+            let jsonData = try JSONEncoder().encode(self)
+            guard let string = String(data: jsonData, encoding: .utf8) else {
+                return NSRegularExpression.escapedPattern(for: self)
+            }
+            let stringWithoutSurroundingQuotes = String(string.dropFirst().dropLast())
+            return NSRegularExpression.escapedPattern(for: stringWithoutSurroundingQuotes)
+        } catch {
+            return NSRegularExpression.escapedPattern(for: self)
         }
     }
 }

--- a/Tests/ResearchKitOnFHIRTests/FHIRToResearchKitTests.swift
+++ b/Tests/ResearchKitOnFHIRTests/FHIRToResearchKitTests.swift
@@ -62,6 +62,19 @@ final class FHIRToResearchKitTests: XCTestCase {
         let itemControlValue = try XCTUnwrap(testItemControl)
         XCTAssertEqual(itemControlValue, "slider")
     }
+    
+    func testCodingRegexPattern() throws {
+        let codingWithDisplay = ValueCoding(code: "medication.value-yes", system: "http://researchkitonfhir.biodesign.stanford.edu/fhir/Coding/medication-value-exists", display: "Yes")
+        let patternWithDisplay = codingWithDisplay.patternForMatchingORKChoiceQuestionResult
+        let expressionWithDisplay = try NSRegularExpression(pattern: patternWithDisplay)
+        let rawValueWithDisplay = codingWithDisplay.rawValue
+        XCTAssert(!expressionWithDisplay.matches(in: rawValueWithDisplay, range: NSRange(location: 0, length: rawValueWithDisplay.count)).isEmpty)
+
+        let codingWithoutDisplay = ValueCoding(code: "medication.value-yes", system: "http://researchkitonfhir.biodesign.stanford.edu/fhir/Coding/medication-value-exists", display: nil)
+        let patternWithoutDisplay = codingWithoutDisplay.patternForMatchingORKChoiceQuestionResult
+        let expressionWithoutDisplay = try NSRegularExpression(pattern: patternWithoutDisplay)
+        XCTAssert(!expressionWithoutDisplay.matches(in: rawValueWithDisplay, range: NSRange(location: 0, length: rawValueWithDisplay.count)).isEmpty)
+    }
 
     func testRegexExtension() throws {
         let testRegex = Questionnaire.textValidationExample.item?.first?.validationRegularExpression


### PR DESCRIPTION
# Coding: Regex pattern

## :recycle: Current situation & Problem
In ENGAGE-HF, we have recently encountered an issue where skip navigation rules didn't work as expected. Unfortunately, my previous changes to include stepIdentifiers in result selectors didn't work as expected and the regex pattern wasn't as expected. Both of these issues should be resolved with this pull request.


## :gear: Release Notes
*Add a bullet point list summary of the feature and possible migration guides if this is a breaking change so this section can be added to the release notes.*
*Include code snippets that provide examples of the feature implemented or links to the documentation if it appends or changes the public interface.*


## :books: Documentation
*Please ensure that you properly document any additions in conformance to [Spezi Documentation Guide](https://github.com/StanfordSpezi/.github/blob/main/DOCUMENTATIONGUIDE.md).*
*You can use this section to describe your solution, but we encourage contributors to document your reasoning and changes using in-line documentation.* 


## :white_check_mark: Testing
*Please ensure that the PR meets the testing requirements set by CodeCov and that new functionality is appropriately tested.*
*This section describes important information about the tests and why some elements might not be testable.*


### Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
